### PR TITLE
Fix broken YAML indentation

### DIFF
--- a/ch2-storage/nginx-pod.yaml
+++ b/ch2-storage/nginx-pod.yaml
@@ -9,6 +9,6 @@ spec:
     volumeMounts:
     - name: web-data
       mountPath: /app/config
- volumes:
- - name: web-data
+  volumes:
+  - name: web-data
 


### PR DESCRIPTION
Fix broken YAML indentation.

Was not possible to `kubectl apply` this file.