### PR TITLE
Fix updateStrategy in YAML

### DIFF
--- a/ch3-cassandra/cassandra-statefulset.yaml
+++ b/ch3-cassandra/cassandra-statefulset.yaml
@@ -8,7 +8,8 @@ spec:
   serviceName: cassandra
   replicas: 3
   podManagementPolicy: OrderedReady
-  updateStrategy: RollingUpdate
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app: cassandra


### PR DESCRIPTION
Fix updateStrategy in YAML. It is a map on Kube 1.21.

I was getting this message:
```
error: error validating "02.yaml": error validating data: ValidationError(StatefulSet.spec.updateStrategy): invalid type for io.k8s.api.apps.v1.StatefulSetUpdateStrategy: got "string", expected "map"; if you choose to ignore these errors, turn validation off with --validate=false
```

I couldn't find when this has been changed in the Kubernetes [changelog](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG) though.