### PR TITLE
Correct storageClassName standard-rwo

### DIFF
--- a/ch3-cassandra/cassandra-statefulset.yaml
+++ b/ch3-cassandra/cassandra-statefulset.yaml
@@ -74,7 +74,7 @@ spec:
       name: cassandra-data
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: standard-rwo
+      storageClassName: standard
       resources:
         requests:
           storage: 1Gi


### PR DESCRIPTION
Correct storageClassName `standard-rwo` with `standard`.